### PR TITLE
power: smb5-lib: Prevent USB switching when PD is active

### DIFF
--- a/drivers/power/supply/qcom/smb5-lib.c
+++ b/drivers/power/supply/qcom/smb5-lib.c
@@ -7979,6 +7979,10 @@ static void set_usb_switch(struct smb_charger *chg, bool enable)
 		return;
 	}
 
+	if (chg->pd_active) {
+		pr_info("%s:pd_active return\n", __func__);
+		return;
+	}
 
 	if (enable) {
 		pr_err("switch on fastchg\n");


### PR DESCRIPTION
This code was present in OOS 10 kernel and without it
headset+charge (or gamepad+charge) adapters aren't working properly.