### PR TITLE
Check smb5-lib.c

### DIFF
--- a/drivers/power/supply/qcom/smb5-lib.c
+++ b/drivers/power/supply/qcom/smb5-lib.c
@@ -7989,10 +7989,7 @@ static void set_usb_switch(struct smb_charger *chg, bool enable)
 
 	if (chg->pd_active) {
 		pr_info("%s:pd_active return\n", __func__);
-		if (chg->typec_mode == POWER_SUPPLY_TYPEC_SINK ||
-				chg->typec_mode == POWER_SUPPLY_TYPEC_SINK_DEBUG_ACCESSORY ||
-				chg->typec_mode == POWER_SUPPLY_TYPEC_SINK_AUDIO_ADAPTER)
-			return;
+		return;
 	}
 
 	if (enable) {


### PR DESCRIPTION
Now, work GameSir X2, with this solution, but some  chargers do not work

I have found that some usbtype C dockstations don't work and also some Joystics like GameSir X2
I think that to find all other chg-> typec_mode exceptions.
For  GameSir X2 or other situations